### PR TITLE
Updating ROC visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ data/Y/
 *.tsv
 figures/
 results/
+*ipynb
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ data/Y/
 *.tsv
 figures/
 results/
-*ipynb
+data/validation
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/nf1_classifier.py
+++ b/scripts/nf1_classifier.py
@@ -187,7 +187,7 @@ def interpolate_roc(df, by=0.01):
     x_post = np.arange(0, 1, by)
     x_pre = [0.0] + list(df.fpr) + [1.0]
     y_pre = [0.0] + list(df.tpr) + [1.0]
-    y_post = np.interp(x_post, xp=x_pre, fp=y_pre)
+    y_post = np.interp(x_post, xp=x_pre, fp=y_pre, left=0, right=1)
     return pd.DataFrame.from_items([('fpr', x_post), ('tpr', y_post)])
 
 

--- a/scripts/viz/viz_roc.r
+++ b/scripts/viz/viz_roc.r
@@ -17,6 +17,7 @@ library(gridExtra)
 
 # Load Command Args
 args <- commandArgs(trailingOnly = T)
+args <- c('results/roc_tdm_output.tsv', 'figures/test_roc_agg_tdm.pdf')
 roc_fh <- args[1]
 roc_figure <- args[2]
 roc_results <- file.path("results",
@@ -103,7 +104,7 @@ roc_grob <- ggplot(roc_data_mean, aes(x = full_mean_fpr, y = tpr,
   geom_line(data = roc_data_aggregate, inherit.aes = FALSE,
             aes(x = mean_fpr, y = tpr, color = type, fill = type,
                 group = interaction(seed, fold, type)), 
-            alpha = 0.15, size = 0.1) +
+            alpha = 0.1, size = 0.1) +
   scale_y_continuous(breaks = c(0, 0.25, 0.50, 0.75, 1.00),
                      limits = c(0, 1)) +
   scale_x_continuous(breaks = c(0, 0.25, 0.50, 0.75, 1.00),

--- a/scripts/viz/viz_roc.r
+++ b/scripts/viz/viz_roc.r
@@ -71,6 +71,10 @@ for (group in unique(roc_data_aggregate$full_group)) {
 roc_data_aggregate <- dplyr::bind_rows(roc_data_aggregate,
                                        do.call(rbind, update_rows))
 
+# Take the mean of the aggregate by iteration
+roc_data_mean <- roc_data_aggregate %>% group_by(type, tpr) %>%
+  summarize(full_mean_fpr = mean(mean_fpr))
+
 # Plot
 base_theme <- theme(panel.grid.major = element_blank(),
                     panel.grid.minor = element_blank(),
@@ -91,16 +95,19 @@ base_theme <- theme(panel.grid.major = element_blank(),
                     legend.text = element_text(size = rel(0.9)),
                     legend.title = element_blank())
 
-roc_grob <- ggplot(roc_data_aggregate, aes(x = mean_fpr, y = tpr,
-                                           color = type, fill = type,
-       group = interaction(seed, fold, type))) +
+roc_grob <- ggplot(roc_data_mean, aes(x = full_mean_fpr, y = tpr,
+                                           color = type, fill = type)) +
   labs(x = "False Positive Rate", y = "True Positive Rate") +
-  geom_line(alpha = 0.3, size = 0.1) + geom_point(size = 0.3, alpha = 0.2) +
+  geom_line(size = rel(0.6)) + geom_point(size = rel(0.4)) +
   geom_abline(intercept = 0, linetype = "dashed", lwd = rel(0.8)) +
+  geom_line(data = roc_data_aggregate, inherit.aes = FALSE,
+            aes(x = mean_fpr, y = tpr, color = type, fill = type,
+                group = interaction(seed, fold, type)), 
+            alpha = 0.15, size = 0.1) +
   scale_y_continuous(breaks = c(0, 0.25, 0.50, 0.75, 1.00),
-                     limits = c(0, 1.0)) +
+                     limits = c(0, 1)) +
   scale_x_continuous(breaks = c(0, 0.25, 0.50, 0.75, 1.00),
-                     limits = c(0, 1.0)) +
+                     limits = c(0, 1)) +
   base_theme + theme(plot.margin = unit(c(0.1, 0, 0, 0), "cm"))
 
 # Summarize the AUROC for each iteration grouped by train/test

--- a/scripts/viz/viz_roc.r
+++ b/scripts/viz/viz_roc.r
@@ -17,14 +17,17 @@ library(gridExtra)
 
 # Load Command Args
 args <- commandArgs(trailingOnly = T)
-roc_fh <- args[1]
-roc_figure <- args[2]
+print(args)
+roc_file <- args[1]
+ensemble_roc_file <- args[2]
+roc_figure <- args[3]
 roc_results <- file.path("results",
                          paste0(tools::file_path_sans_ext(basename(args[2])),
                                 "_auroc.tsv"))
 
 # Load Data
-roc_data <- readr::read_tsv(roc_fh)
+roc_data <- readr::read_tsv(roc_file)
+roc_ensemble <- readr::read_tsv(ensemble_roc_file)
 
 # Save train/test AUROC results
 roc_summary <- roc_data %>%
@@ -75,8 +78,8 @@ base_theme <- theme(panel.grid.major = element_blank(),
                     legend.text = element_text(size = rel(0.9)),
                     legend.title = element_blank())
 
-roc_grob <- ggplot(roc_data_mean, aes(x = full_mean_fpr, y = tpr,
-                                           color = type, fill = type)) +
+roc_grob <- ggplot(roc_ensemble, aes(x = fpr, y = tpr,
+                                     color = type, fill = type)) +
   labs(x = "False Positive Rate", y = "True Positive Rate") +
   geom_line(size = rel(0.6)) + geom_point(size = rel(0.4)) +
   geom_abline(intercept = 0, linetype = "dashed", lwd = rel(0.8)) +

--- a/scripts/viz/viz_roc.r
+++ b/scripts/viz/viz_roc.r
@@ -47,17 +47,6 @@ write.table(auroc_results, roc_results, row.names = F, sep = "\t")
 # Create new variable that stores an ID for each unique iteration
 roc_data <- roc_data %>% mutate(iteration = paste(seed, fold, sep = "_"))
 
-# Aggregate mean false positive rates for each iteration
-roc_data_aggregate <- roc_data %>%
-  group_by(seed, fold, type, tpr) %>%
-  summarise(mean_fpr = mean(fpr)) %>%
-  group_by(seed, fold, type) %>%
-  mutate(full_group = paste(seed, fold, type, sep = "_"))
-
-# Take the mean of the aggregate by iteration
-roc_data_mean <- roc_data_aggregate %>% group_by(type, tpr) %>%
-  summarize(full_mean_fpr = mean(mean_fpr))
-
 # Plot
 base_theme <- theme(panel.grid.major = element_blank(),
                     panel.grid.minor = element_blank(),
@@ -81,10 +70,10 @@ base_theme <- theme(panel.grid.major = element_blank(),
 roc_grob <- ggplot(roc_ensemble, aes(x = fpr, y = tpr,
                                      color = type, fill = type)) +
   labs(x = "False Positive Rate", y = "True Positive Rate") +
-  geom_line(size = rel(0.6)) + geom_point(size = rel(0.4)) +
+  geom_line(size = rel(0.6)) +
   geom_abline(intercept = 0, linetype = "dashed", lwd = rel(0.8)) +
-  geom_step(data = roc_data_aggregate, inherit.aes = FALSE,
-            aes(x = mean_fpr, y = tpr, color = type, fill = type,
+  geom_step(data = roc_data, inherit.aes = FALSE,
+            aes(x = fpr, y = tpr, color = type, fill = type,
                 group = interaction(seed, fold, type)), 
             alpha = 0.1, size = 0.1) +
   scale_y_continuous(breaks = c(0, 0.25, 0.50, 0.75, 1.00),

--- a/scripts/viz/viz_roc.r
+++ b/scripts/viz/viz_roc.r
@@ -17,7 +17,6 @@ library(gridExtra)
 
 # Load Command Args
 args <- commandArgs(trailingOnly = T)
-#args <- c('results/roc_output.tsv', 'figures/GBM_elasticnet_roc_outputalpha_0.15_l1ratio_0.1_roc.pdf')
 roc_fh <- args[1]
 roc_figure <- args[2]
 roc_results <- file.path('results',


### PR DESCRIPTION
Previous figure used loess without standard errors to visualize each of the training/testing partitions across each fold for each random seed. We were losing a lot of information by not plotting the distribution of ROC curves for each iteration.

In this PR, I plot each individual classifier (classifier for each random seed and each cross validation fold) in the ROC curve with loess smoothing.

Here is an example output: [example.pdf](https://github.com/greenelab/nf1_inactivation/files/607598/GBM_elasticnet_roc_outputalpha_0.15_l1ratio_0.1_roc.pdf)
